### PR TITLE
type hint fix.

### DIFF
--- a/src/volttron/auth/authz_manager.py
+++ b/src/volttron/auth/authz_manager.py
@@ -84,7 +84,7 @@ class VolttronAuthzManager(AuthorizationManager):
             self.persistence.store(self._authz_map, file=self.authz_path)
         return result
 
-    def create_or_merge_agent_authz(self, *, identity: str, protected_rpcs: set[authz.vipid_dot_rpc_method] = None,
+    def create_or_merge_agent_authz(self, *, identity: str, protected_rpcs: list[str] = None,
                                    agent_roles: authz.AgentRoles = None, rpc_capabilities: authz.RPCCapabilities = None,
                                    pubsub_capabilities: authz.PubsubCapabilities = None, comments: str = None,
                                    **kwargs) -> bool:

--- a/src/volttron/services/auth/auth_service.py
+++ b/src/volttron/services/auth/auth_service.py
@@ -307,7 +307,7 @@ class VolttronAuthService(AuthService, Agent):
     @RPC.export
     def create_or_merge_agent_authz(self, *,
                                     identity: str,
-                                    protected_rpcs: Optional[list[authz.vipid_dot_rpc_method]] = None,
+                                    protected_rpcs: Optional[list[str]] = None,
                                     roles: Optional[authz.AgentRoles | dict] = None,
                                     rpc_capabilities: Optional[authz.RPCCapabilities | dict] = None,
                                     pubsub_capabilities: Optional[authz.PubsubCapabilities | dict] = None,


### PR DESCRIPTION
 type hint fix. agent's protected rpcs should only be method name not vipid.method